### PR TITLE
Refactor transformation handler

### DIFF
--- a/metadata-mapper-server/src/models/types.ts
+++ b/metadata-mapper-server/src/models/types.ts
@@ -16,10 +16,7 @@ export interface Entity {
 export interface MappingRule {
   sourceField: string;
   targetField: string;
-  transformation?: {
-    type: 'direct' | 'format' | 'convert';
-    config?: Record<string, any>;
-  };
+  transformation?: TransformationConfig;
 }
 
 export interface TransformationConfig {

--- a/metadata-mapper-server/src/services/MetadataService.ts
+++ b/metadata-mapper-server/src/services/MetadataService.ts
@@ -7,6 +7,13 @@ import {
 } from '../models/types';
 
 export class MetadataService {
+  private readonly safeTransforms: Record<string, (value: any) => any> = {
+    toUpperCase: (v: any) => (typeof v === 'string' ? v.toUpperCase() : v),
+    toLowerCase: (v: any) => (typeof v === 'string' ? v.toLowerCase() : v),
+    trim: (v: any) => (typeof v === 'string' ? v.trim() : v),
+    toNumber: (v: any) => Number(v),
+    toString: (v: any) => (v !== undefined && v !== null ? String(v) : v)
+  };
   private getType(value: any): string {
     if (Array.isArray(value)) {
       return `array<${value.length > 0 ? this.getType(value[0]) : 'any'}>`;
@@ -142,10 +149,12 @@ export class MetadataService {
       
       case 'convert':
         if (config.customFunction) {
+          const transform = this.safeTransforms[config.customFunction];
+          if (!transform) {
+            throw new Error(`Unsupported transformation: ${config.customFunction}`);
+          }
           try {
-            // WARNING: This is unsafe and should be replaced with a proper sandbox
-            const fn = new Function('value', config.customFunction);
-            return fn(value);
+            return transform(value);
           } catch (error) {
             console.error('Error in custom transformation:', error);
             throw new Error('Failed to apply custom transformation');
@@ -163,7 +172,11 @@ export class MetadataService {
       rules.forEach(rule => {
         const sourceValue = this.getValueByPath(data, rule.sourceField);
         const transformedValue = rule.transformation
-          ? this.applyTransformation(sourceValue, rule.transformation)
+          ? this.applyTransformation(sourceValue, {
+              ...rule.transformation,
+              sourceType: rule.transformation.sourceType || typeof sourceValue,
+              targetType: rule.transformation.targetType || rule.transformation.sourceType || typeof sourceValue
+            })
           : sourceValue;
         
         this.setValueByPath(result, rule.targetField, transformedValue);


### PR DESCRIPTION
## Summary
- avoid `new Function` in `MetadataService.applyTransformation`
- convert `MappingRule.transformation` to use `TransformationConfig`
- provide a set of safe transformation functions
- default transformation config in `applyMapping`

## Testing
- `npm test --prefix metadata-mapper-server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68767036b2848332abf121630ac51959