### PR TITLE
Add navigation header and about page

### DIFF
--- a/metadata-mapper/src/App.tsx
+++ b/metadata-mapper/src/App.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react'
 import MetadataInput from './components/MetadataInput'
 import MappingRules from './components/MappingRules'
 import MappedResult from './components/MappedResult'
+import Header from './components/Header/Header'
+import About from './components/About'
 
 interface MappingRule {
   sourceField: string;
@@ -10,6 +12,7 @@ interface MappingRule {
 }
 
 function App() {
+  const [page, setPage] = useState<'home' | 'about'>('home');
   const [metadata, setMetadata] = useState('');
   const [mappingRules, setMappingRules] = useState<MappingRule[]>([]);
   const [mappedResult, setMappedResult] = useState<any>(null);
@@ -65,25 +68,28 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gray-100">
+      <Header onNavigate={setPage} currentPage={page} />
       <div className="container mx-auto px-4 py-8">
-        <h1 className="text-3xl font-bold text-center mb-8">Metadata Mapper</h1>
-        
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          <div className="bg-white rounded-lg shadow">
-            <MetadataInput onMetadataChange={handleMetadataChange} />
-          </div>
-          
-          <div className="bg-white rounded-lg shadow">
-            <MappingRules 
-              onRulesChange={handleRulesChange} 
-              metadata={metadata}
-            />
-          </div>
-        </div>
-
-        <div className="mt-6 bg-white rounded-lg shadow">
-          <MappedResult result={mappedResult} error={error} />
-        </div>
+        {page === 'home' ? (
+          <>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              <div className="bg-white rounded-lg shadow">
+                <MetadataInput onMetadataChange={handleMetadataChange} />
+              </div>
+              <div className="bg-white rounded-lg shadow">
+                <MappingRules
+                  onRulesChange={handleRulesChange}
+                  metadata={metadata}
+                />
+              </div>
+            </div>
+            <div className="mt-6 bg-white rounded-lg shadow">
+              <MappedResult result={mappedResult} error={error} />
+            </div>
+          </>
+        ) : (
+          <About />
+        )}
       </div>
     </div>
   )

--- a/metadata-mapper/src/components/About.tsx
+++ b/metadata-mapper/src/components/About.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const About: React.FC = () => (
+  <div className="p-4 space-y-4">
+    <h2 className="text-2xl font-semibold">About Metadata Mapper</h2>
+    <p>
+      This tool helps map your API data to the Entity Metadata Manager (EMM)
+      format. Load your metadata, select the desired fields and generate
+      mapping rules with an easy to use interface.
+    </p>
+  </div>
+);
+
+export default About;

--- a/metadata-mapper/src/components/Header/Header.tsx
+++ b/metadata-mapper/src/components/Header/Header.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface HeaderProps {
+  onNavigate: (page: 'home' | 'about') => void;
+  currentPage: 'home' | 'about';
+}
+
+const Header: React.FC<HeaderProps> = ({ onNavigate, currentPage }) => {
+  return (
+    <header className="bg-blue-600 text-white p-4 flex justify-between items-center">
+      <h1 className="text-xl font-bold">Metadata Mapper</h1>
+      <nav className="space-x-4">
+        <button
+          className={`hover:underline ${currentPage === 'home' ? 'font-semibold' : ''}`}
+          onClick={() => onNavigate('home')}
+        >
+          Home
+        </button>
+        <button
+          className={`hover:underline ${currentPage === 'about' ? 'font-semibold' : ''}`}
+          onClick={() => onNavigate('about')}
+        >
+          About
+        </button>
+      </nav>
+    </header>
+  );
+};
+
+export default Header;


### PR DESCRIPTION
## Summary
- add Header component with simple navigation
- create About page
- integrate new components into App

## Testing
- `npm run lint` *(fails: Cannot find package due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687671bd0a008332be49d4ef4d4d88a6