### PR TITLE
Update OpenWeather entry with env var

### DIFF
--- a/metadata-mapper/.env
+++ b/metadata-mapper/.env
@@ -1,1 +1,2 @@
-VITE_API_URL=http://localhost:3001/api 
+VITE_API_URL=http://localhost:3001/api
+VITE_OPENWEATHER_API_KEY=YOUR_API_KEY

--- a/metadata-mapper/src/data/metadataUrls.ts
+++ b/metadata-mapper/src/data/metadataUrls.ts
@@ -24,10 +24,12 @@ export const metadataUrls: MetadataUrl[] = [
     description: 'Country information in JSON format',
     type: 'json'
   },
+  // Requires a valid key from OpenWeather. Set VITE_OPENWEATHER_API_KEY in your
+  // environment to use this example.
   {
     name: 'Weather API',
-    url: 'https://api.openweathermap.org/data/2.5/weather?q=London&appid=YOUR_API_KEY',
-    description: 'Weather data in JSON format (requires API key)',
+    url: `https://api.openweathermap.org/data/2.5/weather?q=London&appid=${import.meta.env.VITE_OPENWEATHER_API_KEY}`,
+    description: 'Weather data in JSON format',
     type: 'json'
   },
   {


### PR DESCRIPTION
## Summary
- warn users about API key need for OpenWeather and use env var
- add placeholder `VITE_OPENWEATHER_API_KEY` to `.env`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687bb93911708332b5f5e25c3512a6be