### PR TITLE
Add date formatting support

### DIFF
--- a/metadata-mapper-server/package.json
+++ b/metadata-mapper-server/package.json
@@ -5,8 +5,9 @@
   "main": "index.js",
   "scripts": {
     "dev": "ts-node src/index.ts",
-    "start": "node dist/index.js"
-    },
+    "start": "node dist/index.js",
+    "test": "node node_modules/ts-node/dist/bin.js ./src/services/__tests__/MetadataService.test.ts"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/metadata-mapper-server/src/services/MetadataService.ts
+++ b/metadata-mapper-server/src/services/MetadataService.ts
@@ -142,8 +142,14 @@ export class MetadataService {
       
       case 'format':
         if (config.formatString && config.sourceType === 'date') {
-          // TODO: Implement date formatting
-          return value;
+          try {
+            const date = new Date(value);
+            if (isNaN(date.getTime())) return value;
+            return new Intl.DateTimeFormat(config.formatString as string).format(date);
+          } catch (err) {
+            console.error('Error formatting date:', err);
+            throw new Error('Failed to format date');
+          }
         }
         return value;
       

--- a/metadata-mapper-server/src/services/__tests__/MetadataService.test.ts
+++ b/metadata-mapper-server/src/services/__tests__/MetadataService.test.ts
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { MetadataService } from '../MetadataService';
+
+const service = new MetadataService();
+
+const formatted = (service as any).applyTransformation('2024-05-20T12:34:56Z', {
+  type: 'format',
+  sourceType: 'date',
+  targetType: 'string',
+  formatString: 'en-CA'
+});
+
+assert.strictEqual(formatted, '2024-05-20');
+console.log('Date formatting test passed');


### PR DESCRIPTION
## Summary
- implement date formatting via `Intl.DateTimeFormat`
- add simple unit test for the format case
- wire test script in package.json

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bb93101188332a91adab74a579b23